### PR TITLE
Add bool condition on dynamodb lock disable case

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ locals {
   bucket_enabled   = local.enabled && var.bucket_enabled
   dynamodb_enabled = local.enabled && var.dynamodb_enabled
 
-  dynamodb_table_name = coalesce(var.dynamodb_table_name, module.dynamodb_table_label.id)
+  dynamodb_table_name = local.dynamodb_enabled ? coalesce(var.dynamodb_table_name, module.dynamodb_table_label.id) : ""
 
   prevent_unencrypted_uploads = local.enabled && var.prevent_unencrypted_uploads && var.enable_server_side_encryption
 


### PR DESCRIPTION
## what
Add condition to get **dynamo_table_name** when **dynamodb_enabled** is **disable** (false)

## why
Because if you set the **dynamodb_enabled** field to false, the creation fails
## references

